### PR TITLE
Update learnpanion href

### DIFF
--- a/src/covid-footer/lib/covid-footer.tsx
+++ b/src/covid-footer/lib/covid-footer.tsx
@@ -297,7 +297,7 @@ export default function Footer(): JSX.Element {
                 label: intl.formatMessage(labels.schoolClosures),
               },
               {
-                href: 'https://learnpanion.com/',
+                href: 'www.learnpanion.com/',
                 label: intl.formatMessage(labels.learnpanion),
               },
             ]}


### PR DESCRIPTION
Apparently Learnpanion doesn't have https security and the link was a dead one.