### PR TITLE
Add org settings

### DIFF
--- a/components/dashboard/index.tsx
+++ b/components/dashboard/index.tsx
@@ -1,4 +1,5 @@
 export { default as Overview } from './overview';
+export { default as Settings } from './settings';
 export { default as People } from './people';
 export { default as Appts } from './appts';
 export { default as Title } from './title';

--- a/components/dashboard/settings.tsx
+++ b/components/dashboard/settings.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import useTranslation from 'next-translate/useTranslation';
+
+import { Account } from 'lib/model';
+
+import Title from './title';
+import Placeholder from './placeholder';
+
+import styles from './overview.module.scss';
+
+interface SettingsProps {
+  account: Account;
+}
+
+export default function Settings({ account }: SettingsProps): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Title
+        header={t('common:settings')}
+        body={t('settings:subtitle', { name: account.name })}
+      />
+      <div className={styles.wrapper}>
+        <Placeholder>{t('settings:placeholder')}</Placeholder>
+      </div>
+    </>
+  );
+}

--- a/components/header/pop-over.tsx
+++ b/components/header/pop-over.tsx
@@ -185,6 +185,9 @@ export default function PopOverMenu({
               <PopOverLink href='/[org]/appts' as={`/${org.id}/appts`}>
                 {t('common:appts')}
               </PopOverLink>
+              <PopOverLink href='/[org]/settings' as={`/${org.id}/settings`}>
+                {t('common:settings')}
+              </PopOverLink>
             </>
           ))}
           <div className={styles.line} />

--- a/lib/intl/locales/en/common.json
+++ b/lib/intl/locales/en/common.json
@@ -29,6 +29,7 @@
   "search": "Search",
   "profile": "Profile",
   "dashboard": "Dashboard",
+  "settings": "Settings",
   "overview": "Overview",
   "people": "People",
   "appts": "Appointments",

--- a/lib/intl/locales/en/settings.json
+++ b/lib/intl/locales/en/settings.json
@@ -1,0 +1,4 @@
+{
+  "subtitle": "Manage the settings for {{name}}",
+  "placeholder": "COMING SOON"
+}

--- a/lib/model/org.ts
+++ b/lib/model/org.ts
@@ -1,6 +1,6 @@
 import * as admin from 'firebase-admin';
 
-import { Aspect } from './user';
+import { User, UserInterface, Aspect } from './user';
 import { AccountInterface, Account } from './account';
 
 import construct from './construct';
@@ -16,6 +16,23 @@ type DocumentSnapshot = admin.firestore.DocumentSnapshot;
 type IntercomCustomAttribute = string | boolean | number | Date;
 
 /**
+ * Organizational settings.
+ * @property aspects - The aspects offered by (available through) the org (e.g.
+ * some orgs only use one aspect and thus we don't have to use screen real
+ * estate to add aspect tabs).
+ * @property profiles - Profile properties that members can or cannot edit. The
+ * default is that members can edit all their profile properties.
+ * @property notifications - Whether or not to send email notifications to the
+ * members of this org (this is useful when an org admin just wants to play
+ * around with the app w/out sending any emails).
+ */
+export interface OrgSettings {
+  aspects: Aspect[];
+  profiles: Record<keyof UserInterface, boolean>;
+  notifications: boolean;
+}
+
+/**
  * An `Org` object represents a non-profit organization that is using Tutorbook
  * to manage their virtual tutoring programs.
  * @typedef {Object} Org
@@ -24,11 +41,13 @@ type IntercomCustomAttribute = string | boolean | number | Date;
  * what they do to vet their volunteers before adding them to the search view).
  * @property aspect - The default aspect of a given org (i.e. are they more
  * focused on `tutoring` or `mentoring`).
+ * @property settings - Org settings.
  */
 export interface OrgInterface extends AccountInterface {
   members: string[];
   safeguarding: string;
   aspect: Aspect;
+  settings: OrgSettings;
 }
 
 export type OrgJSON = OrgInterface;
@@ -43,6 +62,15 @@ export class Org extends Account implements OrgInterface {
   public safeguarding: string = '';
 
   public aspect: Aspect = 'mentoring';
+
+  public settings: OrgSettings = {
+    aspects: ['mentoring', 'tutoring'],
+    profiles: Object.keys(new User()).reduce(
+      (o: Record<string, boolean>, k: string) => ({ ...o, [k]: true }),
+      {}
+    ) as Record<keyof UserInterface, boolean>,
+    notifications: true,
+  };
 
   public constructor(org: Partial<OrgInterface> = {}) {
     super(org);

--- a/pages/[locale]/[org]/appts.tsx
+++ b/pages/[locale]/[org]/appts.tsx
@@ -171,6 +171,12 @@ function ApptsPage({
             href: '/[org]/appts',
             as: `/${query.org as string}/appts`,
           },
+          {
+            label: t('common:settings'),
+            active: false,
+            href: '/[org]/settings',
+            as: `/${query.org as string}/settings`,
+          },
         ]}
       />
       <Appts

--- a/pages/[locale]/[org]/people.tsx
+++ b/pages/[locale]/[org]/people.tsx
@@ -176,6 +176,12 @@ function PeoplePage({
             href: '/[org]/appts',
             as: `/${query.org as string}/appts`,
           },
+          {
+            label: t('common:settings'),
+            active: false,
+            href: '/[org]/settings',
+            as: `/${query.org as string}/settings`,
+          },
         ]}
       />
       <People

--- a/pages/[locale]/[org]/settings.tsx
+++ b/pages/[locale]/[org]/settings.tsx
@@ -6,7 +6,7 @@ import Footer from 'components/footer';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
-import { Overview } from 'components/dashboard';
+import { Settings } from 'components/dashboard';
 import { TabHeader } from 'components/header';
 import { Org, OrgJSON } from 'lib/model';
 import {
@@ -83,7 +83,7 @@ export const getServerSideProps: GetServerSideProps<
       const org: Org = Org.fromFirestore(doc);
       let props: DashboardPageProps & IntlProps = await getIntlProps(
         { params },
-        ['common', 'overview']
+        ['common', 'settings']
       );
       if (!doc.exists) {
         props = {
@@ -120,7 +120,7 @@ function DashboardPage({
         tabs={[
           {
             label: t('common:overview'),
-            active: true,
+            active: false,
             href: '/[org]/dashboard',
             as: `/${query.org as string}/dashboard`,
           },
@@ -138,13 +138,13 @@ function DashboardPage({
           },
           {
             label: t('common:settings'),
-            active: false,
+            active: true,
             href: '/[org]/settings',
             as: `/${query.org as string}/settings`,
           },
         ]}
       />
-      <Overview account={Org.fromJSON(org as OrgJSON)} />
+      <Settings account={Org.fromJSON(org as OrgJSON)} />
       <Footer />
       <Intercom />
     </>


### PR DESCRIPTION
We're going to create an org settings screen that looks similar to Vercel's (pictured below):

![image](https://user-images.githubusercontent.com/20798889/88686735-3cba0e00-d0ac-11ea-8eb3-362f08d3ea5e.png)

Such a settings and profile screen should enable org admins to:
- Edit the org's profile:
  - Bio
  - Profile image
  - Safeguarding policy
  - Primary aspect (i.e. tutoring or mentoring)
  - Email
  - Phone
  - Socials (e.g. website, Twitter, Facebook, Instagram, LinkedIn)
  - Name
- Add or remove other org admins.
- Update the org's settings:
  - What profile properties users can edit (e.g. one org might not want people changing their price).
  - Whether or not notifications are turned on.
  - What aspects are available in (offered by) the org; this will enable us to increase screen real estate by getting rid of the "mentoring" and "tutoring" tabs if the org only offers one. This should also disable users from editing the other aspect. If we add this setting, we'll probably want to get rid of the `aspect` profile property.