### PR TITLE
Replace map with forEach

### DIFF
--- a/scripts/firebase/picktime.js
+++ b/scripts/firebase/picktime.js
@@ -27,7 +27,7 @@ logger.info(`Loading ${env} environment variables...`);
   path.resolve(__dirname, '../../.env.local'),
   path.resolve(__dirname, `../../.env.${env}`),
   path.resolve(__dirname, `../../.env.${env}.local`),
-].map((path) => {
+].forEach((path) => {
   logger.debug(`Loading .env file (${path})...`);
   dotenv.config({ path });
 });


### PR DESCRIPTION
The callback provided to the map call on this array should return a value, otherwise map will always return an array of undefined values. If the desired behaviour is to just iterate through all elements, then consider using forEach or a for-of loop instead.