### PR TITLE
perf: replace icon fonts with SVGs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn pretty-quick
+yarn pretty-quick --staged

--- a/components/availability-select/timeslot-rnd.tsx
+++ b/components/availability-select/timeslot-rnd.tsx
@@ -12,6 +12,8 @@ import { ResizeDirection } from 're-resizable';
 import dynamic from 'next/dynamic';
 import useTranslation from 'next-translate/useTranslation';
 
+import CloseIcon from 'components/icons/close';
+
 import { TCallback } from 'lib/model/callback';
 import { Timeslot } from 'lib/model/timeslot';
 
@@ -120,7 +122,11 @@ export default function TimeslotRnd({
       }}
     >
       <div className={styles.wrapper}>
-        <IconButton className={styles.btn} icon='close' onClick={remove} />
+        <IconButton
+          className={styles.btn}
+          icon={<CloseIcon />}
+          onClick={remove}
+        />
         <div className={styles.content}>
           <div>
             {value.from.toLocaleString(locale, {

--- a/components/calendar/dialog/create-page.tsx
+++ b/components/calendar/dialog/create-page.tsx
@@ -4,6 +4,7 @@ import { TextField } from '@rmwc/textfield';
 import useTranslation from 'next-translate/useTranslation';
 
 import Button from 'components/button';
+import CloseIcon from 'components/icons/close';
 import Loader from 'components/loader';
 import MatchSelect from 'components/match-select';
 import RecurSelect from 'components/recur-select';
@@ -119,7 +120,7 @@ export default function CreatePage({
     <div className={styles.wrapper}>
       <Loader active={!!loading} checked={!!checked} />
       <div className={styles.nav}>
-        <IconButton icon='close' className={styles.btn} onClick={nav} />
+        <IconButton icon={<CloseIcon />} className={styles.btn} onClick={nav} />
       </div>
       <form className={styles.form} onSubmit={onEditStop}>
         <div className={styles.inputs}>

--- a/components/calendar/dialog/display-page.tsx
+++ b/components/calendar/dialog/display-page.tsx
@@ -3,7 +3,11 @@ import { IconButton } from '@rmwc/icon-button';
 import Link from 'next/link';
 
 import Avatar from 'components/avatar';
+import CloseIcon from 'components/icons/close';
+import DeleteIcon from 'components/icons/delete';
+import EditIcon from 'components/icons/edit';
 import Loader from 'components/loader';
+import OpenInNewIcon from 'components/icons/open-in-new';
 import { useNav } from 'components/dialog/context';
 
 import { getRecurString, join } from 'lib/utils';
@@ -33,9 +37,9 @@ export default function DisplayPage({
     <div className={styles.wrapper}>
       <Loader active={!!loading} checked={!!checked} />
       <div className={styles.nav}>
-        <IconButton icon='close' className={styles.btn} onClick={nav} />
+        <IconButton icon={<CloseIcon />} className={styles.btn} onClick={nav} />
         <Link href={`/${editing.match.org}/matches/${editing.match.id}`}>
-          <IconButton icon='open_in_new' className={styles.btn} />
+          <IconButton icon={<OpenInNewIcon />} className={styles.btn} />
         </Link>
       </div>
       <div className={styles.content}>
@@ -69,11 +73,15 @@ export default function DisplayPage({
       <div className={styles.actions}>
         <ChipSet className={styles.chips}>
           <Chip
-            icon='edit'
+            icon={<EditIcon />}
             label='Edit meeting'
             onClick={() => setDialogPage(DialogPage.Edit)}
           />
-          <Chip icon='delete' label='Delete meeting' onClick={onDeleteStop} />
+          <Chip
+            icon={<DeleteIcon />}
+            label='Delete meeting'
+            onClick={onDeleteStop}
+          />
         </ChipSet>
       </div>
     </div>

--- a/components/calendar/dialog/edit-page.tsx
+++ b/components/calendar/dialog/edit-page.tsx
@@ -4,6 +4,7 @@ import { TextField } from '@rmwc/textfield';
 import useTranslation from 'next-translate/useTranslation';
 
 import Button from 'components/button';
+import CloseIcon from 'components/icons/close';
 import Loader from 'components/loader';
 import RecurSelect from 'components/recur-select';
 import SubjectSelect from 'components/subject-select';
@@ -115,7 +116,7 @@ export default function EditPage({
       <Loader active={!!loading} checked={!!checked} />
       <div className={styles.nav}>
         <IconButton
-          icon='close'
+          icon={<CloseIcon />}
           className={styles.btn}
           onClick={() => setDialogPage(DialogPage.Display)}
         />

--- a/components/calendar/dialog/page.module.scss
+++ b/components/calendar/dialog/page.module.scss
@@ -14,10 +14,15 @@
     padding: 12px 14px;
 
     .btn {
-      font-size: 18px;
       padding: 9px;
       width: 36px;
       height: 36px;
+
+      svg {
+        display: block;
+        height: 18px;
+        width: 18px;
+      }
     }
   }
 }

--- a/components/calendar/search-bar.tsx
+++ b/components/calendar/search-bar.tsx
@@ -3,6 +3,9 @@ import { IconButton } from '@rmwc/icon-button';
 import { TextField } from '@rmwc/textfield';
 import { dequal } from 'dequal/lite';
 
+import DownloadIcon from 'components/icons/download';
+import FilterListIcon from 'components/icons/filter-list';
+
 import { Callback } from 'lib/model/callback';
 import { MeetingsQuery } from 'lib/model/query/meetings';
 
@@ -32,10 +35,12 @@ function SearchBar({
           <IconButton
             className={styles.filtersButton}
             onClick={() => setFiltersOpen((prev) => !prev)}
-            icon='filter_list'
+            icon={<FilterListIcon />}
           />
         )}
-        {byOrg && <IconButton icon='download' onClick={downloadResults} />}
+        {byOrg && (
+          <IconButton icon={<DownloadIcon />} onClick={downloadResults} />
+        )}
       </div>
       <div className={styles.right}>
         <TextField

--- a/components/calendar/search-bar.tsx
+++ b/components/calendar/search-bar.tsx
@@ -33,13 +33,18 @@ function SearchBar({
       <div className={styles.left}>
         {byOrg && (
           <IconButton
+            data-cy='filters-button'
             className={styles.filtersButton}
             onClick={() => setFiltersOpen((prev) => !prev)}
             icon={<FilterListIcon />}
           />
         )}
         {byOrg && (
-          <IconButton icon={<DownloadIcon />} onClick={downloadResults} />
+          <IconButton
+            data-cy='download-button'
+            onClick={downloadResults}
+            icon={<DownloadIcon />}
+          />
         )}
       </div>
       <div className={styles.right}>

--- a/components/carousel/carousel.tsx
+++ b/components/carousel/carousel.tsx
@@ -20,13 +20,9 @@ export default class Carousel extends React.Component<
   CarouselProps,
   CarouselState
 > {
-  private readonly scrollerRef: React.RefObject<
-    HTMLDivElement
-  > = React.createRef();
+  private readonly scrollerRef: React.RefObject<HTMLDivElement> = React.createRef();
 
-  private readonly childRef: React.RefObject<
-    HTMLDivElement
-  > = React.createRef();
+  private readonly childRef: React.RefObject<HTMLDivElement> = React.createRef();
 
   public constructor(props: CarouselProps) {
     super(props);

--- a/components/carousel/carousel.tsx
+++ b/components/carousel/carousel.tsx
@@ -2,6 +2,9 @@ import { IconButton } from '@rmwc/icon-button';
 import React from 'react';
 import { v4 as uuid } from 'uuid';
 
+import ChevronLeftIcon from 'components/icons/chevron-left';
+import ChevronRightIcon from 'components/icons/chevron-right';
+
 import styles from './carousel.module.scss';
 
 interface CarouselProps {
@@ -83,13 +86,13 @@ export default class Carousel extends React.Component<
             style={this.atStart ? hidden : {}}
             onClick={this.scrollLeft}
             className={styles.left}
-            icon='chevron_left'
+            icon={<ChevronLeftIcon />}
           />
           <IconButton
             style={this.atEnd ? hidden : {}}
             onClick={this.scrollRight}
             className={styles.right}
-            icon='chevron_right'
+            icon={<ChevronRightIcon />}
           />
           <div
             className={styles.scroller}

--- a/components/icons/add.tsx
+++ b/components/icons/add.tsx
@@ -1,0 +1,13 @@
+export default function Add(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z' />
+    </svg>
+  );
+}

--- a/components/icons/chevron-left.tsx
+++ b/components/icons/chevron-left.tsx
@@ -1,0 +1,13 @@
+export default function ChevronLeft(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z' />
+    </svg>
+  );
+}

--- a/components/icons/chevron-right.tsx
+++ b/components/icons/chevron-right.tsx
@@ -1,0 +1,13 @@
+export default function ChevronRight(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z' />
+    </svg>
+  );
+}

--- a/components/icons/close.tsx
+++ b/components/icons/close.tsx
@@ -1,0 +1,13 @@
+export default function Close(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z' />
+    </svg>
+  );
+}

--- a/components/icons/contact-support.tsx
+++ b/components/icons/contact-support.tsx
@@ -1,0 +1,13 @@
+export default function ContactSupport(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M11.5 2C6.81 2 3 5.81 3 10.5S6.81 19 11.5 19h.5v3c4.86-2.34 8-7 8-11.5C20 5.81 16.19 2 11.5 2zm1 14.5h-2v-2h2v2zm0-3.5h-2c0-3.25 3-3 3-5 0-1.1-.9-2-2-2s-2 .9-2 2h-2c0-2.21 1.79-4 4-4s4 1.79 4 4c0 2.5-3 2.75-3 5z' />
+    </svg>
+  );
+}

--- a/components/icons/delete.tsx
+++ b/components/icons/delete.tsx
@@ -1,0 +1,13 @@
+export default function Delete(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z' />
+    </svg>
+  );
+}

--- a/components/icons/download.tsx
+++ b/components/icons/download.tsx
@@ -1,0 +1,13 @@
+export default function Download(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0V0z' fill='none' />
+      <path d='M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z' />
+    </svg>
+  );
+}

--- a/components/icons/edit.tsx
+++ b/components/icons/edit.tsx
@@ -1,0 +1,13 @@
+export default function Edit(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z' />
+    </svg>
+  );
+}

--- a/components/icons/fact-check.tsx
+++ b/components/icons/fact-check.tsx
@@ -1,0 +1,23 @@
+export default function FactCheck(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      enableBackground='new 0 0 24 24'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <g>
+        <rect fill='none' height='24' width='24' />
+      </g>
+      <g>
+        <g>
+          <path
+            d='M20,3H4C2.9,3,2,3.9,2,5v14c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V5 C22,3.9,21.1,3,20,3z M10,17H5v-2h5V17z M10,13H5v-2h5V13z M10,9H5V7h5V9z M14.82,15L12,12.16l1.41-1.41l1.41,1.42L17.99,9 l1.42,1.42L14.82,15z'
+            fillRule='evenodd'
+          />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/components/icons/filter-list.tsx
+++ b/components/icons/filter-list.tsx
@@ -1,0 +1,13 @@
+export default function FilterList(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z' />
+    </svg>
+  );
+}

--- a/components/icons/open-in-new.tsx
+++ b/components/icons/open-in-new.tsx
@@ -1,0 +1,13 @@
+export default function OpenInNew(): JSX.Element {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      height='24'
+      viewBox='0 0 24 24'
+      width='24'
+    >
+      <path d='M0 0h24v24H0z' fill='none' />
+      <path d='M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z' />
+    </svg>
+  );
+}

--- a/components/matches/index.tsx
+++ b/components/matches/index.tsx
@@ -14,6 +14,7 @@ import { nanoid } from 'nanoid';
 import useSWR from 'swr';
 import useTranslation from 'next-translate/useTranslation';
 
+import DownloadIcon from 'components/icons/download';
 import Header from 'components/header';
 import Pagination from 'components/pagination';
 import Placeholder from 'components/placeholder';
@@ -130,7 +131,7 @@ export default function Matches({
               <IconButton
                 className={styles.downloadButton}
                 onClick={downloadResults}
-                icon='download'
+                icon={<DownloadIcon />}
               />
             )}
           </div>

--- a/components/navigation/pop-over.module.scss
+++ b/components/navigation/pop-over.module.scss
@@ -98,8 +98,10 @@
       -moz-box-align: center;
       align-items: center;
 
-      > i {
-        font-size: 20px !important;
+      svg {
+        width: 20px;
+        height: 20px;
+        fill: currentColor;
       }
     }
   }

--- a/components/navigation/pop-over.tsx
+++ b/components/navigation/pop-over.tsx
@@ -1,13 +1,14 @@
-import { Fragment, useState } from 'react';
+import { Fragment, ReactNode, useState } from 'react';
 import { MenuSurface, MenuSurfaceAnchor } from '@rmwc/menu';
 import { FormField } from '@rmwc/formfield';
-import { Icon } from '@rmwc/icon';
 import { Ripple } from '@rmwc/ripple';
 import { Switch } from '@rmwc/switch';
 import cn from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
+import AddIcon from 'components/icons/add';
 import Avatar from 'components/avatar';
+import ContactSupportIcon from 'components/icons/contact-support';
 import Intercom from 'lib/intercom';
 
 import { AccountInterface } from 'lib/model/account';
@@ -22,7 +23,7 @@ import styles from './pop-over.module.scss';
 interface PopOverLinkProps {
   href: string;
   children: string;
-  icon?: string;
+  icon?: ReactNode;
 }
 
 export function PopOverLink({
@@ -34,11 +35,7 @@ export function PopOverLink({
     /* eslint-disable jsx-a11y/anchor-is-valid */
     <Ripple>
       <div className={styles.item}>
-        {icon && (
-          <div className={styles.icon}>
-            <Icon icon={icon} />
-          </div>
-        )}
+        {icon && <div className={styles.icon}>{icon}</div>}
         <Link href={href}>
           <a className={styles.itemLink}>{children}</a>
         </Link>
@@ -51,7 +48,7 @@ export function PopOverLink({
 interface PopOverButtonProps {
   onClick: () => void;
   children: string;
-  icon?: string;
+  icon?: ReactNode;
   id?: string;
 }
 
@@ -64,11 +61,7 @@ export function PopOverButton({
   return (
     <Ripple>
       <button id={id} type='button' onClick={onClick} className={styles.item}>
-        {icon && (
-          <div className={styles.icon}>
-            <Icon icon={icon} />
-          </div>
-        )}
+        {icon && <div className={styles.icon}>{icon}</div>}
         <span className={styles.label}>{children}</span>
       </button>
     </Ripple>
@@ -202,14 +195,14 @@ export default function PopOverMenu({
           <div className={styles.line} />
           <PopOverButton
             id='create-org'
-            icon='add'
+            icon={<AddIcon />}
             onClick={() => Intercom('showNewMessage', t('common:new-org-msg'))}
           >
             {t('common:new-org-btn')}
           </PopOverButton>
           <PopOverButton
             id='get-help'
-            icon='contact_support'
+            icon={<ContactSupportIcon />}
             onClick={() => Intercom('show')}
           >
             {t('common:launch-intercom')}

--- a/components/navigation/switcher.tsx
+++ b/components/navigation/switcher.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 
+import AddIcon from 'components/icons/add';
 import Intercom from 'lib/intercom';
 
 import { Org } from 'lib/model/org';
@@ -66,7 +67,7 @@ export default function Switcher(): JSX.Element {
           )}
           <div className={styles.line} />
           <PopOverButton
-            icon='add'
+            icon={<AddIcon />}
             onClick={() => Intercom('showNewMessage', t('common:new-org-msg'))}
           >
             {t('common:new-org-btn')}

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -3,6 +3,9 @@ import { IconButton } from '@rmwc/icon-button';
 import { Select } from '@rmwc/select';
 import useTranslation from 'next-translate/useTranslation';
 
+import ChevronLeftIcon from 'components/icons/chevron-left';
+import ChevronRightIcon from 'components/icons/chevron-right';
+
 import { Callback } from 'lib/model/callback';
 import { Query } from 'lib/model/query';
 
@@ -58,12 +61,12 @@ export default function Pagination<T extends Query>({
         </div>
         <IconButton
           disabled={query.page <= 0}
-          icon='chevron_left'
+          icon={<ChevronLeftIcon />}
           onClick={pageLeft}
         />
         <IconButton
           disabled={query.page + 1 >= hits / query.hitsPerPage}
-          icon='chevron_right'
+          icon={<ChevronRightIcon />}
           onClick={pageRight}
         />
       </div>

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -15,6 +15,8 @@ import { MDCMenuSurfaceFoundation } from '@material/menu-surface';
 import { nanoid } from 'nanoid';
 import to from 'await-to-js';
 
+import CloseIcon from 'components/icons/close';
+
 import { Option } from 'lib/model/query/base';
 import { TCallback } from 'lib/model/callback';
 import { useClickContext } from 'lib/hooks/click-outside';
@@ -346,7 +348,7 @@ export default function Select<T, O extends Option<T>>({
                   : opt.label
               }
               label={opt.label}
-              trailingIcon='close'
+              trailingIcon={<CloseIcon />}
               onTrailingIconInteraction={() => updateSelected(opt)}
               className={styles.chip}
             />

--- a/components/time-select/select-surface.tsx
+++ b/components/time-select/select-surface.tsx
@@ -17,6 +17,9 @@ import useMeasure from 'react-use-measure';
 import useSWR from 'swr';
 import useTranslation from 'next-translate/useTranslation';
 
+import ChevronLeftIcon from 'components/icons/chevron-left';
+import ChevronRightIcon from 'components/icons/chevron-right';
+
 import { Availability, AvailabilityJSON } from 'lib/model/availability';
 import {
   getDate,
@@ -119,13 +122,13 @@ function SelectSurface({
           </h6>
           <div className={styles.navigation}>
             <IconButton
-              icon='chevron_left'
+              icon={<ChevronLeftIcon />}
               onClick={viewPrevMonth}
               disabled={getMonthsApart(selected) <= 0}
               data-cy='prev-month-button'
             />
             <IconButton
-              icon='chevron_right'
+              icon={<ChevronRightIcon />}
               onClick={viewNextMonth}
               disabled={getMonthsApart(selected) >= 3}
               data-cy='next-month-button'

--- a/components/user/display.module.scss
+++ b/components/user/display.module.scss
@@ -115,16 +115,18 @@
         left: 8px;
 
         button {
-          @include icon-button.size(32px);
           background: var(--primary);
           color: var(--on-primary);
           border-radius: 50%;
-          font-size: 18px;
           margin: 0 4px;
+          height: 32px;
+          width: 32px;
+          padding: (32px - 18px) / 2;
 
           svg {
             width: 18px;
             height: 18px;
+            display: block;
           }
 
           &:first-child {

--- a/components/user/display.module.scss
+++ b/components/user/display.module.scss
@@ -122,6 +122,11 @@
           font-size: 18px;
           margin: 0 4px;
 
+          svg {
+            width: 18px;
+            height: 18px;
+          }
+
           &:first-child {
             margin-left: 0;
           }

--- a/components/user/display.tsx
+++ b/components/user/display.tsx
@@ -6,6 +6,8 @@ import cn from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
 import Avatar from 'components/avatar';
+import EditIcon from 'components/icons/edit';
+import FactCheckIcon from 'components/icons/fact-check';
 import RequestForm from 'components/user/request-form';
 
 import { getEmailLink, getPhoneLink, join } from 'lib/utils';
@@ -104,10 +106,10 @@ export default function UserDisplay({
           {user && admin && currentUser.id !== user.id && (
             <div className={styles.actions}>
               <Link href={`/${org?.id || ''}/users/${user?.id || ''}/edit`}>
-                <IconButton icon='edit' label='Edit user' />
+                <IconButton icon={<EditIcon />} label='Edit user' />
               </Link>
               <Link href={`/${org?.id || ''}/users/${user?.id || ''}/vet`}>
-                <IconButton icon='fact_check' label='Vet user' />
+                <IconButton icon={<FactCheckIcon />} label='Vet user' />
               </Link>
             </div>
           )}

--- a/components/users/header.tsx
+++ b/components/users/header.tsx
@@ -63,13 +63,15 @@ export default memo(function Header({
     return Intercom('showNewMessage', t('users:import-data-msg'));
   }, [t]);
 
+  // TODO: Once the types are updated, restore the snackbar's SVG dismiss icon.
+  // @see {@link https://github.com/jamesmfriedman/rmwc/pull/727}
+
   return (
     <>
       {snackbar && (
         <Snackbar
           onClose={hideSnackbar}
           message={t('users:link-copied')}
-          dismissIcon
           leading
           open
         />

--- a/components/users/search-bar.tsx
+++ b/components/users/search-bar.tsx
@@ -30,11 +30,13 @@ function SearchBar({ query, setQuery, setOpen }: SearchBarProps): JSX.Element {
     <div className={styles.filters}>
       <div className={styles.left}>
         <IconButton
+          data-cy='filters-button'
           className={styles.filtersButton}
           onClick={() => setOpen((prev) => !prev)}
           icon={<FilterListIcon />}
         />
         <IconButton
+          data-cy='download-button'
           onClick={() => window.open(query.getURL('/api/users/csv'))}
           icon={<DownloadIcon />}
         />

--- a/components/users/search-bar.tsx
+++ b/components/users/search-bar.tsx
@@ -4,6 +4,9 @@ import { IconButton } from '@rmwc/icon-button';
 import { TextField } from '@rmwc/textfield';
 import useTranslation from 'next-translate/useTranslation';
 
+import FilterListIcon from 'components/icons/filter-list';
+import DownloadIcon from 'components/icons/download';
+
 import { Callback } from 'lib/model/callback';
 import { UsersQuery } from 'lib/model/query/users';
 import { useOrg } from 'lib/context/org';
@@ -29,11 +32,11 @@ function SearchBar({ query, setQuery, setOpen }: SearchBarProps): JSX.Element {
         <IconButton
           className={styles.filtersButton}
           onClick={() => setOpen((prev) => !prev)}
-          icon='filter_list'
+          icon={<FilterListIcon />}
         />
         <IconButton
           onClick={() => window.open(query.getURL('/api/users/csv'))}
-          icon='download'
+          icon={<DownloadIcon />}
         />
         <ChipSet className={styles.filterChips}>
           <Chip

--- a/cypress/tests/authentication-failed.spec.ts
+++ b/cypress/tests/authentication-failed.spec.ts
@@ -6,20 +6,23 @@ describe('Authentication failed page', () => {
   });
 
   it('shows authentication failed message', () => {
-    cy.getBySel('page').find('h3').should('have.text', 'Authentication Failed');
-    cy.get('p')
-      .should('have.length', 2)
-      .first()
-      .should(
-        'have.text',
-        'It looks like you may have clicked on an invalid email verification link.'
-      );
-    cy.get('p')
-      .last()
-      .should(
-        'have.text',
-        'Please close this window and try authenticating again.'
-      );
+    cy.getBySel('page').within(() => {
+      cy.get('h3').should('have.text', 'Authentication Failed');
+      cy.get('p')
+        .should('have.length', 2)
+        .first()
+        .should(
+          'have.text',
+          'It looks like you may have clicked on an invalid email verification link.'
+        );
+      cy.get('p')
+        .last()
+        .should(
+          'have.text',
+          'Please close this window and try authenticating again.'
+        );
+    });
+
     cy.wait('@get-account');
     cy.percySnapshot('Authentication Failed Page');
   });

--- a/cypress/tests/awaiting-confirm.spec.ts
+++ b/cypress/tests/awaiting-confirm.spec.ts
@@ -10,19 +10,21 @@ describe('Awaiting confirmation page', () => {
     cy.visit(`/awaiting-confirm?email=${student.email}`);
     cy.wait('@get-account');
 
-    cy.getBySel('page').find('h3').should('have.text', 'Awaiting Confirmation');
-    cy.get('p')
-      .should('have.length', 2)
-      .first()
-      .should('have.text', `We just sent an email to ${student.email}.`)
-      .children('b')
-      .should('have.text', student.email);
-    cy.get('p')
-      .last()
-      .should(
-        'have.text',
-        'Click the confirmation button in that email to continue.'
-      );
+    cy.getBySel('page').within(() => {
+      cy.get('h3').should('have.text', 'Awaiting Confirmation');
+      cy.get('p')
+        .should('have.length', 2)
+        .first()
+        .should('have.text', `We just sent an email to ${student.email}.`)
+        .children('b')
+        .should('have.text', student.email);
+      cy.get('p')
+        .last()
+        .should(
+          'have.text',
+          'Click the confirmation button in that email to continue.'
+        );
+    });
 
     cy.percySnapshot('Awaiting Confirm Page for Students');
   });
@@ -31,12 +33,21 @@ describe('Awaiting confirmation page', () => {
     cy.visit('/awaiting-confirm');
     cy.wait('@get-account');
 
-    cy.get('p')
-      .should('have.length', 2)
-      .first()
-      .should('have.text', 'We just sent an email to your-email@domain.com.')
-      .children('b')
-      .should('have.text', 'your-email@domain.com');
+    cy.getBySel('page').within(() => {
+      cy.get('h3').should('have.text', 'Awaiting Confirmation');
+      cy.get('p')
+        .should('have.length', 2)
+        .first()
+        .should('have.text', 'We just sent an email to your-email@domain.com.')
+        .children('b')
+        .should('have.text', 'your-email@domain.com');
+      cy.get('p')
+        .last()
+        .should(
+          'have.text',
+          'Click the confirmation button in that email to continue.'
+        );
+    });
 
     cy.percySnapshot('Awaiting Confirm Page');
   });

--- a/cypress/tests/org/search.spec.ts
+++ b/cypress/tests/org/search.spec.ts
@@ -218,10 +218,7 @@ describe('Search page', () => {
     cy.focused()
       .parent()
       .within(() => {
-        cy.get('.mdc-chip')
-          .first()
-          .contains('[role="button"]', 'close')
-          .click();
+        cy.get('.mdc-chip').first().find('[role="button"]').last().click();
         cy.get('.mdc-chip').should('have.length', 0);
         cy.percySnapshot('Search Page with Subject Selected');
       });

--- a/cypress/tests/org/search.spec.ts
+++ b/cypress/tests/org/search.spec.ts
@@ -72,7 +72,9 @@ describe('Search page', () => {
     // TODO: Perhaps make assertions about the 'api/users' query to remove this
     // awkward result item selection timeout workaround.
     cy.wait('@list-users');
-    cy.getBySel('result', { timeout: 60000 })
+    cy.getBySel('result')
+      .should('not.have.css', 'cursor', 'wait')
+      .as('results')
       .should('have.length', 1)
       .first()
       .should('contain', volunteer.name)
@@ -91,7 +93,7 @@ describe('Search page', () => {
     cy.get('header').contains('button', 'Tutors').should('not.exist');
 
     cy.wait('@list-users');
-    cy.getBySel('result').as('results').should('have.length', 2);
+    cy.get('@results').should('have.length', 2);
     cy.get('@results')
       .eq(0)
       .should('contain', volunteer.name)
@@ -119,7 +121,10 @@ describe('Search page', () => {
     cy.percySnapshot('Search Page in Loading State');
 
     cy.wait('@list-users');
-    cy.getBySel('result').as('results').should('have.length', 2);
+    cy.getBySel('result')
+      .should('not.have.css', 'cursor', 'wait')
+      .as('results')
+      .should('have.length', 2);
     cy.get('@results')
       .eq(0)
       .should('not.contain', volunteer.name)
@@ -142,7 +147,7 @@ describe('Search page', () => {
     cy.wait('@list-users');
     cy.get('@results')
       .should('have.length', 1)
-      .should('not.have.attr', 'disabled', '')
+      .and('not.have.attr', 'disabled', '')
       .children('a')
       .should('contain', onlyFirstNameAndLastInitial(admin.name))
       .and(

--- a/cypress/tests/org/users/id/index.spec.ts
+++ b/cypress/tests/org/users/id/index.spec.ts
@@ -136,6 +136,9 @@ function selectTime(they: boolean = false): void {
     )
   );
 
+  if (selected.getMonth() === now.getMonth() + 1)
+    cy.getBySel('next-month-button').trigger('click');
+
   cy.get('@days')
     .eq(selected.getDate() - 1)
     .trigger('click')

--- a/cypress/tests/org/users/index.spec.ts
+++ b/cypress/tests/org/users/index.spec.ts
@@ -21,8 +21,11 @@ function snackbarIsOpen(label: string = 'Link copied to clipboard.'): void {
     .should('be.visible')
     .find('.mdc-snackbar__label')
     .should('have.text', label);
-  cy.get('@snackbar').find('button').click();
-  cy.get('@snackbar').should('not.exist');
+
+  // TODO: Restore this once we can use SVGs for the snackbar dismiss button.
+  // @see {@link https://github.com/jamesmfriedman/rmwc/pull/727}
+  // cy.get('@snackbar').find('button').click();
+  // cy.get('@snackbar').should('not.exist');
 }
 
 // TODO: Add `cy.percySnapshot` calls to add visual snapshot testing.

--- a/cypress/tests/org/users/index.spec.ts
+++ b/cypress/tests/org/users/index.spec.ts
@@ -153,7 +153,7 @@ describe('Users page', () => {
 
     // Showing featured mentors first; users must be visible in search AND speak
     // Spanish.
-    cy.contains('button', 'filter_list').as('filters-button').click();
+    cy.getBySel('filters-button').click();
     filterSheetIsOpen();
     cy.contains('Languages').as('langs-input').type('spanish');
 
@@ -176,7 +176,7 @@ describe('Users page', () => {
       .should('have.length', 1)
       .first()
       .should('contain', volunteer.name);
-    cy.get('@spanish-chip').contains('[role="button"]', 'close').click();
+    cy.get('@spanish-chip').find('[role="button"]').last().click();
     cy.get('@langs-input').children('.mdc-chip').should('have.length', 0);
 
     // Showing featured mentors first; users must be visible in search AND not
@@ -200,7 +200,7 @@ describe('Users page', () => {
       .should('have.length', 1)
       .first()
       .should('contain', volunteer.name);
-    cy.get('@filters-button').click();
+    cy.getBySel('filters-button').click();
     filterSheetIsOpen(false);
 
     // Showing featured tutors first; users must not yet be vetted.
@@ -218,7 +218,7 @@ describe('Users page', () => {
 
     // Showing featured tutors first; users must not yet be vetted AND must
     // tutor Computer Science.
-    cy.get('@filters-button').click();
+    cy.getBySel('filters-button').click();
     filterSheetIsOpen();
     cy.contains('Subjects').as('subjects-input').type('computer');
     cy.get('@portal')
@@ -237,9 +237,9 @@ describe('Users page', () => {
       .should('have.length', 1)
       .first()
       .should('contain', volunteer.name);
-    cy.get('@cs-chip').contains('[role="button"]', 'close').click();
+    cy.get('@cs-chip').find('[role="button"]').last().click();
     cy.get('@subjects-input').children('.mdc-chip').should('have.length', 0);
-    cy.get('@filters-button').click();
+    cy.getBySel('filters-button').click();
     filterSheetIsOpen(false);
 
     // Search by text (using 'Erik' name).

--- a/cypress/tests/org/users/index.spec.ts
+++ b/cypress/tests/org/users/index.spec.ts
@@ -50,7 +50,7 @@ describe('Users page', () => {
     cy.url({ timeout: 60000 }).should('contain', url);
   });
 
-  it('fallbacks to invisible textarea copy-paste', () => {
+  it('falls back to invisible textarea copy-paste', () => {
     cy.login(admin.id);
     cy.visit(`/${school.id}/users`, {
       onBeforeLoad(win: Window): void {

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -26,7 +26,6 @@
 
 @use '@rmwc/tooltip/tooltip';
 
-@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 @import 'social-icons';
 @import 'nprogress';
 @import 'material';

--- a/styles/material.css
+++ b/styles/material.css
@@ -131,6 +131,16 @@
   color: var(--on-background-5);
 }
 
+.mdc-chip__icon svg {
+  width: 100%;
+  height: 100%;
+  fill: var(--on-background-4);
+}
+
+.mdc-chip__icon svg:hover {
+  fill: var(--on-background-5);
+}
+
 .mdc-chip__checkmark-path {
   stroke: var(--on-background);
 }


### PR DESCRIPTION
- [x] Replace all uses of icons in `IconButton`s with SVGs (finished by #155).
- [x] Check for other references to the `Material Icons` font in RMWC.
- [x] Remove the `Material Icons` font import from `styles/global.scss` and ensure nothing breaks.

Blocked by jamesmfriedman/rmwc#727 until we can also update the snackbar's dismiss icon to be an SVG.