### PR TITLE
perf: treeshaking for models in meeting

### DIFF
--- a/lib/mail/meetings/create/direct-template.tsx
+++ b/lib/mail/meetings/create/direct-template.tsx
@@ -8,7 +8,8 @@ import {
   MeetingDisplay,
   P,
 } from 'lib/mail/components';
-import { Meeting, User } from 'lib/model';
+import { Meeting } from 'lib/model/meeting';
+import { User } from 'lib/model/user';
 import { getEmailLink, getPhoneLink } from 'lib/utils';
 
 export interface DirectMeetingEmailProps {

--- a/lib/mail/meetings/create/index.tsx
+++ b/lib/mail/meetings/create/index.tsx
@@ -1,6 +1,8 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { Meeting, Org, User } from 'lib/model';
+import { Meeting } from 'lib/model/meeting';
+import { Org } from 'lib/model/org';
+import { User } from 'lib/model/user';
 import { Email } from 'lib/mail/types';
 import { join } from 'lib/utils';
 import send from 'lib/mail/send';

--- a/lib/mail/meetings/create/org-direct-template.tsx
+++ b/lib/mail/meetings/create/org-direct-template.tsx
@@ -8,7 +8,9 @@ import {
   MeetingDisplay,
   P,
 } from 'lib/mail/components';
-import { Meeting, Org, User } from 'lib/model';
+import { Meeting } from 'lib/model/meeting';
+import { Org } from 'lib/model/org';
+import { User } from 'lib/model/user';
 
 export interface OrgDirectMeetingEmailProps {
   org: Org;

--- a/lib/mail/meetings/create/org-template.tsx
+++ b/lib/mail/meetings/create/org-template.tsx
@@ -8,7 +8,9 @@ import {
   MeetingDisplay,
   P,
 } from 'lib/mail/components';
-import { Meeting, Org, User } from 'lib/model';
+import { Meeting } from 'lib/model/meeting';
+import { Org } from 'lib/model/org';
+import { User } from 'lib/model/user';
 import { join } from 'lib/utils';
 
 export interface OrgMeetingEmailProps {

--- a/lib/mail/meetings/create/template.tsx
+++ b/lib/mail/meetings/create/template.tsx
@@ -8,7 +8,9 @@ import {
   MeetingDisplay,
   P,
 } from 'lib/mail/components';
-import { Meeting, Org, User } from 'lib/model';
+import { Meeting } from 'lib/model/meeting';
+import { Org } from 'lib/model/org';
+import { User } from 'lib/model/user';
 import { getEmailLink, getPhoneLink, join } from 'lib/utils';
 
 export interface MeetingEmailProps {


### PR DESCRIPTION
Perf: Tree shaking for model imports.

I have shaken the model imports for the meeting functionality inside the mail component as a start.